### PR TITLE
Fix tokenizer training

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -8,10 +8,10 @@ stages:
       size: 15098090914
       nfiles: 36
     - path: scripts/train_tokenizer.py
-      md5: 359f70a34419410129a85aed82c688aa
-      size: 2402
+      md5: 57eb4f5df01695bc0ccccf13eb76490d
+      size: 3193
     outs:
     - path: data/tokenizer
-      md5: 8d24d09dc3fd027eb7621224e4c5074c.dir
-      size: 1342354
-      nfiles: 1
+      md5: 1777251e74bbd4e6999fb9799a30f968.dir
+      size: 3125460
+      nfiles: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ convention = "google"
 
 [tool.ruff.per-file-ignores]
 "stubs/**/*" = ["D101", "D102", "D103", "D105", "D107"]
+"test/**/*" = ["D"]
 
 [tool.mypy]
 # start with strict and explicitly relax some conditions

--- a/stubs/sentencepiece.pyi
+++ b/stubs/sentencepiece.pyi
@@ -8,9 +8,16 @@ from typing import BinaryIO, Iterator
 
 class SentencePieceProcessor:
     def __init__(self, model_file: str, num_threads: int = -1) -> None: ...
+    def id_to_piece(self, id: int) -> str: ...
+    def get_score(self, id: int) -> float: ...
+    def get_piece_size(self) -> int: ...
 
 class SentencePieceTrainer:
     @staticmethod
     def train(
-        sentence_iterator: Iterator[str], model_writer: BinaryIO, vocab_size: int = 8000
+        sentence_iterator: Iterator[str],
+        model_writer: BinaryIO,
+        vocab_size: int = 8000,
+        character_coverage: float = 0.9995,
+        pad_id: int = -1,
     ) -> None: ...

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ description = Check static type annotations with mypy.
 extras = train, types
 base_python = py310
 commands =
-    mypy {posargs:src scripts}
+    mypy {posargs:src scripts test}

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ description = Check static type annotations with mypy.
 extras = train, types
 base_python = py310
 commands =
-    mypy {posargs:src scripts test}
+    mypy {posargs:src scripts}


### PR DESCRIPTION
Add pad token which is disabled by default and use full character coverage, since less that 1.0 coverge is recommended only for "character-rich" languages like chinese or japanese.